### PR TITLE
Add User-Agent to prevent 403 on HTTPS request for news feed

### DIFF
--- a/launcher/src/main/java/com/skcraft/launcher/swing/WebpagePanel.java
+++ b/launcher/src/main/java/com/skcraft/launcher/swing/WebpagePanel.java
@@ -249,6 +249,7 @@ public final class WebpagePanel extends JPanel {
             try {
                 conn = (HttpURLConnection) url.openConnection();
                 conn.setRequestMethod("GET");
+                conn.addRequestProperty("User-Agent", "");
                 conn.setUseCaches(false);
                 conn.setDoInput(true);
                 conn.setDoOutput(false);


### PR DESCRIPTION
SKCraft#248
Without specifying a User-Agent property in the request, a response code of 403 is returned.

(Needs attention)