### PR TITLE
Fix extraction of folders inside ZipExtract

### DIFF
--- a/launcher/src/main/java/com/skcraft/launcher/install/ZipExtract.java
+++ b/launcher/src/main/java/com/skcraft/launcher/install/ZipExtract.java
@@ -46,7 +46,11 @@ public class ZipExtract implements Runnable {
             while ((entry = zis.getNextEntry()) != null) {
                 if (matches(entry)) {
                     File file = new File(getDestination(), entry.getName());
-                    writeEntry(zis, file);
+                    if (entry.isDirectory()) {
+                        file.mkdirs();
+                    } else {
+                        writeEntry(zis, file);
+                    }
                 }
             }
         } catch (IOException e) {


### PR DESCRIPTION
SKCraft#271
Extracting libs like` libraries/com/mojang/text2speech/1.10.3/text2speech-1.10.3.jar `with directories containing only directories rules in a error because ZipExtract create an empty file instead a folder.